### PR TITLE
Adds exponential backoff on websocket reconnection

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 [
+  import_deps: [:skogsra],
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 80
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.1.6
+
+### Changes
+
+  * [Enhancement] Added exponential backoff to the websocket reconnection
+    retries.
+  * [Enhancement] Added the possibility of configuring the node URLs from
+    environment variables or Elixir configuration to override the defaults.
+  * [Enhancement] Improved websocket test code coverage.
+  * [Enhancement] The websocket now reconnects to the last know height when
+    height is available and being updated.
+
 ## v0.1.5
 
 ### Changes

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ iex> Yggdrasil.unsubscribe(channel)
 > iex> Yggdrasil.subscribe(channel)
 > :ok
 > ```
-> 
+>
 > For more info about the notifications, check the next section.
 
 ### Example: Subscribing to Events

--- a/lib/icon/application.ex
+++ b/lib/icon/application.ex
@@ -3,6 +3,7 @@ defmodule Icon.Application do
   use Application
 
   alias Icon.Config
+  alias Yggdrasil.Config.Icon, as: YggdrasilConfig
 
   @spec start(Application.start_type(), any()) ::
           {:ok, pid()}
@@ -11,6 +12,7 @@ defmodule Icon.Application do
   @impl Application
   def start(_type, _args) do
     Config.validate!()
+    YggdrasilConfig.validate!()
 
     children = [
       {Finch, name: Icon.Finch},

--- a/lib/icon/application.ex
+++ b/lib/icon/application.ex
@@ -2,12 +2,16 @@ defmodule Icon.Application do
   @moduledoc false
   use Application
 
+  alias Icon.Config
+
   @spec start(Application.start_type(), any()) ::
           {:ok, pid()}
           | {:ok, pid(), any()}
           | {:error, any()}
   @impl Application
   def start(_type, _args) do
+    Config.validate!()
+
     children = [
       {Finch, name: Icon.Finch},
       {Yggdrasil.Adapter.Icon, []}

--- a/lib/icon/config.ex
+++ b/lib/icon/config.ex
@@ -1,0 +1,61 @@
+defmodule Icon.Config do
+  @moduledoc """
+  This module defines different configuration variables for the ICON 2.0 SDK.
+  """
+  use Skogsra
+
+  @envdoc """
+  Mainnet node: this is a node connected to the ICON 2.0 network and it'll be
+  used as the default options when creating an `Icon.RPC.Identity`.
+
+  ```elixir
+  iex> Icon.Config.mainnet_node!()
+  "https://ctz.solidwallet.io"
+  ```
+  """
+  app_env :mainnet_node, :icon, :mainnet_node,
+    required: true,
+    os_env: "MAINNET_NODE",
+    default: "https://ctz.solidwallet.io"
+
+  @envdoc """
+  Sejong node: this is a test network node for applications without audit.
+
+  ```elixir
+  iex> Icon.Config.sejong_node!()
+  "https://sejong.net.solidwallet.io"
+  ```
+  """
+  app_env :sejong_node, :icon, :sejong_node,
+    required: true,
+    os_env: "SEJONG_NODE",
+    default: "https://sejong.net.solidwallet.io"
+
+  @envdoc """
+  Berlin node: this is a test network node that offers the latest features and
+  may be unstable. Resets happen frequently without notice.
+
+  ```elixir
+  iex> Icon.Config.berlin_node!()
+  "https://berlin.net.solidwallet.io"
+  ```
+  """
+  app_env :berlin_node, :icon, :berlin_node,
+    required: true,
+    os_env: "BERLIN_NODE",
+    default: "https://berlin.net.solidwallet.io"
+
+  @envdoc """
+  Lisbon node: this is a test network node with long term support which
+  environment is the closest to mainnet.
+
+  ```elixir
+  iex> Icon.Config.lisbon_node!()
+  "https://lisbon.net.solidwallet.io"
+  ```
+  """
+  app_env :lisbon_node, :icon, :lisbon_node,
+    required: true,
+    os_env: "LISBON_NODE",
+    default: "https://lisbon.net.solidwallet.io"
+end

--- a/lib/icon/rpc/identity.ex
+++ b/lib/icon/rpc/identity.ex
@@ -98,21 +98,8 @@ defmodule Icon.RPC.Identity do
     debug: false
   ]>
   ```
-
-  ### BTP
-
-  This is the new BTP test network. Thus anything related to BTP should be
-  tested here.
-
-  ```elixir
-  iex> Icon.RPC.Identity.new(network_id: :btp)
-  #Identity<[
-    node: "https://btp.net.solidwallet.io",
-    network_id: "0x42 (BTP)",
-    debug: false
-  ]>
-  ```
   """
+  alias Icon.Config
 
   @doc """
   Connection struct.
@@ -137,7 +124,7 @@ defmodule Icon.RPC.Identity do
   @typedoc """
   Network name.
   """
-  @type network_name :: :mainnet | :sejong | :berlin | :lisbon | :btp
+  @type network_name :: :mainnet | :sejong | :berlin | :lisbon
 
   @typedoc """
   Initialization option.
@@ -227,10 +214,6 @@ defmodule Icon.RPC.Identity do
     add_network_id(identity, 2)
   end
 
-  defp add_network_id(%__MODULE__{} = identity, :btp) do
-    add_network_id(identity, 66)
-  end
-
   defp add_network_id(%__MODULE__{} = identity, "0x" <> _ = network_id) do
     network_id =
       network_id
@@ -250,23 +233,19 @@ defmodule Icon.RPC.Identity do
   defp add_node(identity, node)
 
   defp add_node(%__MODULE__{network_id: 1} = identity, nil) do
-    add_node(identity, "https://ctz.solidwallet.io")
+    add_node(identity, Config.mainnet_node!())
   end
 
   defp add_node(%__MODULE__{network_id: 83} = identity, nil) do
-    add_node(identity, "https://sejong.net.solidwallet.io")
+    add_node(identity, Config.sejong_node!())
   end
 
   defp add_node(%__MODULE__{network_id: 7} = identity, nil) do
-    add_node(identity, "https://berlin.net.solidwallet.io")
+    add_node(identity, Config.berlin_node!())
   end
 
   defp add_node(%__MODULE__{network_id: 2} = identity, nil) do
-    add_node(identity, "https://lisbon.net.solidwallet.io")
-  end
-
-  defp add_node(%__MODULE__{network_id: 66} = identity, nil) do
-    add_node(identity, "https://btp.net.solidwallet.io")
+    add_node(identity, Config.lisbon_node!())
   end
 
   defp add_node(%__MODULE__{} = identity, node) when is_binary(node) do
@@ -356,7 +335,6 @@ defimpl Inspect, for: Icon.RPC.Identity do
   defp network_name(%Identity{network_id: 83}), do: "0x53 (Sejong)"
   defp network_name(%Identity{network_id: 7}), do: "0x7 (Berlin)"
   defp network_name(%Identity{network_id: 2}), do: "0x2 (Lisbon)"
-  defp network_name(%Identity{network_id: 66}), do: "0x42 (BTP)"
 
   defp network_name(%Identity{network_id: network_id}) do
     network_id

--- a/lib/yggdrasil/config/icon.ex
+++ b/lib/yggdrasil/config/icon.ex
@@ -1,0 +1,57 @@
+defmodule Yggdrasil.Config.Icon do
+  @moduledoc """
+  This module defines configuration variables for ICON 2.0 WebSocket connection.
+  """
+  use Skogsra
+
+  @envdoc """
+  WebSocket max retries for the backoff algorithm. Defaults to `3`.
+
+  The backoff algorithm is exponential:
+
+  ```
+  backoff_time = retries² * random(1, slot) * 1_000ms
+  ```
+  where:
+
+  - `retries` is less or equal to `max_retries!/0`,
+  - and `slot` is given by `slot_size!/0`.
+
+  ```elixir
+  iex> Yggdrasil.Config.Icon.max_retries!()
+  3
+  ```
+  """
+  app_env :max_retries, :yggdrasil_icon, :max_retries,
+    required: true,
+    default: 3
+
+  @envdoc """
+  WebSocket slot size for the backoff algorithm. Defaults to `10`.
+
+  The backoff algorithm is exponential:
+
+  ```
+  backoff_time = retries² * random(1, slot) * 1_000ms
+  ```
+  where:
+
+  - `retries` is less or equal to `max_retries!/0`,
+  - and `slot` is given by `slot_size!/0`.
+
+  ```elixir
+  iex> Yggdrasil.Config.Icon.slot_size!()
+  10
+  ```
+  """
+  app_env :slot_size, :yggdrasil_icon, :slot_size,
+    required: true,
+    default: 10
+
+  # For testing purposes.
+  @envdoc false
+  app_env :websocket_module, :yggdrasil_icon, :websocket_module,
+    binding_order: [:config],
+    type: :module,
+    default: Yggdrasil.Subscriber.Adapter.Icon.WebSocket
+end

--- a/lib/yggdrasil/subscriber/adapter/icon.ex
+++ b/lib/yggdrasil/subscriber/adapter/icon.ex
@@ -44,6 +44,7 @@ defmodule Yggdrasil.Subscriber.Adapter.Icon do
   alias __MODULE__, as: State
   alias Icon.RPC.Identity
   alias Icon.Schema
+  alias Icon.Schema.Types.Block.Tick
   alias Yggdrasil.Channel
   alias Yggdrasil.Config.Icon, as: Config
   alias Yggdrasil.Subscriber.Adapter.Icon.Message
@@ -175,6 +176,11 @@ defmodule Yggdrasil.Subscriber.Adapter.Icon do
   def handle_info({ref, :connected}, %State{} = state)
       when is_reference(ref) do
     {:noreply, state, {:continue, :connected}}
+  end
+
+  def handle_info({ref, {:ok, %Tick{height: height}}}, %State{} = state)
+      when is_reference(ref) and is_integer(height) and height > 0 do
+    {:noreply, %{state | height: height}}
   end
 
   def handle_info({ref, {:error, %Schema.Error{} = error}}, %State{} = state)
@@ -323,6 +329,16 @@ defmodule Yggdrasil.Subscriber.Adapter.Icon do
        )
        when is_integer(height) do
     {:ok, %{state | height: height}}
+  end
+
+  defp add_height(
+         %State{
+           height: height,
+           channel: %Channel{name: %{source: :block}}
+         } = state
+       )
+       when is_integer(height) and height > 0 do
+    {:ok, state}
   end
 
   defp add_height(%State{channel: %Channel{name: info}} = state) do

--- a/lib/yggdrasil/subscriber/adapter/icon/message.ex
+++ b/lib/yggdrasil/subscriber/adapter/icon/message.ex
@@ -61,12 +61,13 @@ defmodule Yggdrasil.Subscriber.Adapter.Icon.Message do
 
   @spec do_publish(Channel.t(), binary() | map()) ::
           :ok
+          | :connected
           | {:error, Schema.Error.t()}
   defp do_publish(%Channel{} = channel, notification)
        when is_binary(notification) do
     case Jason.decode(notification) do
       {:ok, %{"code" => 0}} ->
-        :ok
+        :connected
 
       {:ok, %{"code" => code, "message" => message}} ->
         {:error, Schema.Error.new(code: code, message: message)}

--- a/lib/yggdrasil/subscriber/adapter/icon/web_socket.ex
+++ b/lib/yggdrasil/subscriber/adapter/icon/web_socket.ex
@@ -1,0 +1,83 @@
+defmodule Yggdrasil.Subscriber.Adapter.Icon.WebSocket do
+  use WebSockex
+  alias __MODULE__, as: State
+  alias Yggdrasil.Subscriber.Adapter.Icon
+
+  @doc false
+  defstruct url: nil,
+            subscriber: nil
+
+  @typedoc false
+  @type t :: %State{
+          url: url :: binary(),
+          subscriber: pid()
+        }
+
+  ############
+  # Public API
+
+  @doc """
+  Starts a websocket connection with an `url` and some `options`.
+  """
+  @spec start_link(binary(), WebSockex.options()) ::
+          {:ok, pid()}
+          | {:error, term()}
+  def start_link(url, options) do
+    state = %__MODULE__{url: url, subscriber: self()}
+
+    WebSockex.start_link(url, __MODULE__, state, options)
+  end
+
+  @doc """
+  Stops `websocket`.
+  """
+  @spec stop(WebSockex.client()) :: :ok
+  def stop(websocket) do
+    if Process.alive?(websocket),
+      do: WebSockex.cast(websocket, :stop),
+      else: :ok
+  end
+
+  @doc """
+  Initializes `websocket` connection with a `message`.
+  """
+  @spec initialize(WebSockex.client(), term()) :: :ok
+  def initialize(websocket, message) do
+    WebSockex.cast(websocket, {:init, message})
+  end
+
+  #####################
+  # WebSockex callbacks
+
+  @impl WebSockex
+  def handle_connect(%WebSockex.Conn{}, %State{subscriber: pid} = state) do
+    Icon.send_connected(pid)
+    {:ok, state}
+  end
+
+  @impl WebSockex
+  def handle_cast({:init, message}, %State{} = state) do
+    {:reply, message, state}
+  end
+
+  def handle_cast(:stop, %State{} = state) do
+    {:close, state}
+  end
+
+  @impl WebSockex
+  def handle_frame(frame, %State{subscriber: pid} = state) do
+    Icon.send_frame(pid, frame)
+    {:ok, state}
+  end
+
+  @impl WebSockex
+  def handle_disconnect(_status, %State{} = state) do
+    {:ok, state}
+  end
+
+  @impl WebSockex
+  def terminate(reason, %State{subscriber: pid} = _state) do
+    Icon.send_disconnected(pid, reason)
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Icon.MixProject do
   use Mix.Project
 
-  @version "0.1.5"
+  @version "0.1.6"
   @name "ICON 2.0 SDK"
   @description "Basic API for interacting with ICON 2.0 blockchain"
   @app :icon

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Icon.MixProject do
       {:curvy, "~> 0.3"},
       {:websockex, "~> 0.4"},
       {:yggdrasil, "~> 6.0"},
+      {:skogsra, "~> 2.3"},
       {:bypass, "~> 2.1", only: :test},
       {:plug_cowboy, "~> 2.0", pnly: :test},
       {:ex_doc, "~> 0.28", only: :dev, runtime: false},
@@ -100,7 +101,8 @@ defmodule Icon.MixProject do
   defp groups_for_modules do
     [
       "ICON 2.0 SDK": [
-        Icon
+        Icon,
+        Icon.Config
       ],
       "JSON RPC v3": [
         Icon.RPC.Identity,

--- a/test/icon/config_test.exs
+++ b/test/icon/config_test.exs
@@ -1,0 +1,4 @@
+defmodule Icon.ConfigTest do
+  use ExUnit.Case, async: true
+  doctest Icon.Config
+end

--- a/test/icon/rpc/identity_test.exs
+++ b/test/icon/rpc/identity_test.exs
@@ -69,18 +69,6 @@ defmodule Icon.RPC.IdentityTest do
              } = Identity.new(network_id: :lisbon)
     end
 
-    test "sets BTP network id" do
-      assert %Identity{network_id: 66} = Identity.new(network_id: :btp)
-      assert %Identity{network_id: 66} = Identity.new(network_id: "0x42")
-      assert %Identity{network_id: 66} = Identity.new(network_id: 66)
-    end
-
-    test "sets default BTP node when none provided" do
-      assert %Identity{
-               node: "https://btp.net.solidwallet.io"
-             } = Identity.new(network_id: :btp)
-    end
-
     test "sets custom node even when network id is provided" do
       node = "https://custom.solidwallet.io"
 
@@ -175,12 +163,6 @@ defmodule Icon.RPC.IdentityTest do
       identity = Identity.new(network_id: :lisbon)
 
       assert inspect(identity) =~ ~s/network_id: "0x2 (Lisbon)"/
-    end
-
-    test "sets network id for BTP" do
-      identity = Identity.new(network_id: :btp)
-
-      assert inspect(identity) =~ ~s/network_id: "0x42 (BTP)"/
     end
 
     test "sets other network id" do

--- a/test/support/web_socket/server.ex
+++ b/test/support/web_socket/server.ex
@@ -2,7 +2,7 @@ defmodule Icon.WebSocket.Server do
   @moduledoc false
   @behaviour :cowboy_websocket
 
-  defstruct [:host, :caller, :handler, :path, :bypass, :req]
+  defstruct [:host, :caller, :path, :req]
 
   @impl :cowboy_websocket
   def init(req, [params]) do
@@ -20,8 +20,8 @@ defmodule Icon.WebSocket.Server do
   end
 
   @impl :cowboy_websocket
-  def websocket_info({:send, frame, pid}, state) do
-    send(pid, :ok)
+  def websocket_info({:send, frame}, state) do
+    send(state.caller, :ok)
     {:reply, frame, state}
   end
 

--- a/test/yggdrasil/config/icon_test.exs
+++ b/test/yggdrasil/config/icon_test.exs
@@ -1,0 +1,4 @@
+defmodule Yggdrasil.Config.IconTest do
+  use ExUnit.Case, async: true
+  doctest Yggdrasil.Config.Icon
+end

--- a/test/yggdrasil/subscriber/adapter/icon/message_test.exs
+++ b/test/yggdrasil/subscriber/adapter/icon/message_test.exs
@@ -30,7 +30,7 @@ defmodule Yggdrasil.Subscriber.Adapter.Icon.MessageTest do
       channel: channel
     } do
       %Task{ref: ref} = Message.publish(channel, ~s({"code":0}))
-      assert_receive {^ref, :ok}
+      assert_receive {^ref, :connected}
     end
 
     test "fails on error websocket setup", %{

--- a/test/yggdrasil/subscriber/adapter/icon/web_socket_test.exs
+++ b/test/yggdrasil/subscriber/adapter/icon/web_socket_test.exs
@@ -1,0 +1,35 @@
+defmodule Yggdrasil.Subscriber.Adapter.Icon.WebSocketTest do
+  use ExUnit.Case, async: true
+
+  alias Icon.WebSocket.Router
+  alias Yggdrasil.Subscriber.Adapter.Icon.WebSocket
+
+  setup do
+    %Router{url: url} = router = Router.start()
+
+    {:ok, url: url, router: router}
+  end
+
+  test "when websocket is connected, sends connected message", %{url: url} do
+    assert {:ok, _websocket} = WebSocket.start_link(url, [])
+    assert_receive {:websocket, _}
+    assert_receive {:"$gen_cast", :connected}
+  end
+
+  test "when websocket is terminated, sends disconnected message", %{url: url} do
+    assert {:ok, websocket} = WebSocket.start_link(url, [])
+    assert_receive {:websocket, _}
+    assert_receive {:"$gen_cast", :connected}
+    assert :ok = WebSocket.stop(websocket)
+    assert_receive {:"$gen_cast", {:disconnected, {:local, :normal}}}
+  end
+
+  test "sends frames when received", %{url: url, router: router} do
+    assert {:ok, websocket} = WebSocket.start_link(url, [])
+    :ok = WebSocket.initialize(websocket, {:text, ~s({"height":"0x2a"})})
+    _router = Router.trigger_message(router, %{"height" => "0x2a"})
+    assert_receive {:"$gen_cast", :connected}
+    assert_receive {:"$gen_cast", {:frame, {:text, ~s({"code":0})}}}
+    assert_receive {:"$gen_cast", {:frame, {:text, ~s({"height":"0x2a"})}}}
+  end
+end


### PR DESCRIPTION
This PR improves the re-connection mechanism for the ICON 2.0 Yggdrasil adapter:

- [x] Adds exponential backoff when reconnecting.
- [x] Splits ICON 2.0 WebSocket protocol from the actual WebSocket connection.
- [x] Tracks last block height when available and re-connects using that height instead of the latest one (this prevent having notification gaps).
- [x] Improves test code coverage for WebSocket.

These changes make the websocket connection more resilient.

Additionally, I've added a way to configure the nodes URLs in case we want to override the default globally.

The API continues to be the same.

![](https://media.giphy.com/media/D7z8JfNANqahW/giphy.gif)